### PR TITLE
Fix: cmake clean issue (lib.rs.cc not found after cleaning the build directory)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ target_include_directories(
 
 target_link_libraries(cpp_with_rust ${BLOBSTORE_LIB})
 
+set_target_properties(
+    cpp_with_rust
+    PROPERTIES ADDITIONAL_CLEAN_FILES ${CARGO_TARGET_DIR}
+)
+
 # Windows-only configuration
 if(WIN32)
     target_link_libraries(cpp_with_rust userenv ws2_32 bcrypt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_custom_command(
         COMMAND cargo build --manifest-path ${CARGO_MANIFEST}
         DEPENDS ${BLOBSTORE_SOURCE_FILE}
         USES_TERMINAL
+        COMMENT "Running cargo..."
 )
 
 add_executable(cpp_with_rust src/main.cpp src/multibuf.cpp ${BLOBSTORE_BRIDGE_CPP})
@@ -30,8 +31,8 @@ target_include_directories(
 target_link_libraries(cpp_with_rust ${BLOBSTORE_LIB})
 
 set_target_properties(
-    cpp_with_rust
-    PROPERTIES ADDITIONAL_CLEAN_FILES ${CARGO_TARGET_DIR}
+        cpp_with_rust
+        PROPERTIES ADDITIONAL_CLEAN_FILES ${CARGO_TARGET_DIR}
 )
 
 # Windows-only configuration


### PR DESCRIPTION
Closes #1 

This issue can be triggered by the `cmake clean` target after a successful build. Any other build attempt after that will trigger the reported error. It doesn't matter if the build tool is GNU Make or Ninja. For instance:

~~~
cd cpp-with-rust
cmake -S . -B build
# (configuration succeeds)
cmake --build build/
# (build succeeds)
cmake --build build/ --target clean
# (clean removes two files)
cmake --build build/
# (build fails!)
~~~

Another available workaround is running `cargo clean` before building. It fully removes the target/ directory. 

The problem is that the `cmake clean` target removes the `OUTPUT` files generated by `add_custom_command()`, but cargo doesn't know how to regenerate them when the target directory is already populated by the last `cargo` execution.

The `COMMENT` message added to `add_custom_command()` proves that cmake tries to run cargo whenever the `${BLOBSTORE_BRIDGE_CPP}` file is missing. The message is printed no matter if the build fails.  

My first attempt to fix this issue was adding `BYPRODUCTS ${CARGO_TARGET_DIR}` to `add_custom_command()`, which works fine if  the CMake generator is GNU Make, but fails for Ninja. The alternative is to set the  `ADDITIONAL_CLEAN_FILES` property on the main target, which emulates the `cargo clean` effects.
